### PR TITLE
Adding plausible blog post view event

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -69,5 +69,9 @@ const ogImage = coverImage
     ">
       <slot />
     </article>
+    <!-- Plausible send blog post view event -->
+    <script>
+      window.plausible && plausible('Blog Post View', { props: { title: '{title}' } });
+    </script>
   </div>
 </BaseLayout>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -72,7 +72,7 @@ const ogImage = coverImage
     <!-- Plausible send blog post view event -->
     <script define:vars={{ title }}>
       const location = window.location.href;
-      window.plausible && plausible('Blog Post View', { props: { title: { title } } });
+      window.plausible && plausible('Blog Post View', { props: { title: title } });
     </script>
   </div>
 </BaseLayout>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -71,7 +71,8 @@ const ogImage = coverImage
     </article>
     <!-- Plausible send blog post view event -->
     <script>
-      window.plausible && plausible('Blog Post View', { props: { title: '{title}' } });
+      const location = window.location.href;
+      window.plausible && plausible('Blog Post View', { props: { title: { title } } });
     </script>
   </div>
 </BaseLayout>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -72,7 +72,7 @@ const ogImage = coverImage
     <!-- Plausible send blog post view event -->
     <script define:vars={{ title }}>
       const location = window.location.href;
-      window.plausible && plausible('Blog Post View', { props: { title: title } });
+      window.plausible && plausible('Blog Post View', { props: { title } });
     </script>
   </div>
 </BaseLayout>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -70,7 +70,7 @@ const ogImage = coverImage
       <slot />
     </article>
     <!-- Plausible send blog post view event -->
-    <script>
+    <script define:vars={{ title }}>
       const location = window.location.href;
       window.plausible && plausible('Blog Post View', { props: { title: { title } } });
     </script>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -70,9 +70,8 @@ const ogImage = coverImage
       <slot />
     </article>
     <!-- Plausible send blog post view event -->
-    <script define:vars={{ title }}>
-      const location = window.location.href;
-      window.plausible && plausible('Blog Post View', { props: { title } });
+    <script>
+      window.plausible?.('Blog Post View', { props: { title:document.title } });
     </script>
   </div>
 </BaseLayout>


### PR DESCRIPTION
This pull request adds analytics tracking for blog post views using Plausible in the `PostLayout.astro` file. Now, when a blog post is viewed, a custom event is sent to Plausible with the post title as a property.

Analytics integration:

* Added a Plausible script to trigger a 'Blog Post View' event with the post title as a property when a blog post is viewed. (`src/layouts/PostLayout.astro`)