### PR TITLE
Add site-wide search with Pagefind

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,66 @@ npm run build     # Production build to ./dist
 npm run preview   # Preview production build locally
 ```
 
+## Search
+
+Site-wide search is powered by [Pagefind](https://pagefind.app) — a static search
+index built from the site's own HTML. There's no backend and no third-party service;
+the index ships as static files alongside the rest of the site.
+
+**The index is built automatically by `npm run build`.** The `build` script runs
+`astro build && pagefind --site dist/client`, so the Pagefind step always runs against
+the freshly built HTML. Nothing extra to remember when publishing.
+
+> **Note:** `pagefind` is pointed at `dist/client`, not `dist`. The Cloudflare adapter
+> emits static HTML into `dist/client/` and the worker into `dist/server/`, and the
+> generated deploy config serves `dist/client` as the site root. Indexing `dist` would
+> record every result URL with a `/client/` prefix and write the index outside the
+> served asset root, so `/pagefind/` would 404 in production.
+
+### Testing search locally
+
+The index only exists in `dist/` — **`npm run dev` has no `/pagefind/` directory**, so
+the search page will show a "search is unavailable" message there. That's expected. To
+try search for real, build first:
+
+```bash
+npm run build && npm run preview
+# Visit http://localhost:8787/search
+```
+
+`npm run preview` already runs `npm run build` for you, so a bare `npm run preview` is
+enough — the two-step form above is just explicit about what's happening.
+
+### What gets indexed
+
+Pagefind only indexes elements marked with `data-pagefind-body`, and skips any page
+without one:
+
+| Location | Indexed |
+|----------|---------|
+| `src/layouts/PostLayout.astro` | Post title, date, categories and rendered markdown |
+| `src/pages/about.astro`, `tools.astro`, `contact.astro` | The page's own `<section>` |
+| Home, `/blog` archive pages, `/404`, `/search` | Not indexed — they only aggregate content indexed elsewhere |
+
+Scoping this way keeps the `Header.astro` nav and `Footer.astro` text out of the index,
+so site chrome never shows up as a match on every result.
+
+**When adding a new page**, add `data-pagefind-body` to the element wrapping its content
+if you want it searchable. Posts get it automatically from `PostLayout.astro`.
+
+### The search page
+
+`/search` (`src/pages/search.astro`) mounts Pagefind's default UI. It accepts a `?q=`
+query parameter, so you can link to a pre-run search from anywhere on the site:
+
+```html
+<a href="/search?q=passkeys">Search for passkeys</a>
+```
+
+Pagefind's default styles are re-themed to the site's palette in a `<style is:global>`
+block on that page, scoped under `#search` so the overrides can't leak into another
+Pagefind instance added later.
+
 ## Adding a New Post
 
 ### Quick start — use the script
@@ -111,6 +171,7 @@ src/
     ├── index.astro      # Home page
     ├── about.astro
     ├── contact.astro
+    ├── search.astro     # Pagefind search UI
     ├── tools.astro
     └── blog/
         ├── [...page].astro   # Paginated post archive

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "tailwindcss": "^4.1.13"
       },
       "devDependencies": {
+        "pagefind": "^1.5.2",
         "wrangler": "^4.68.0"
       }
     },
@@ -1292,6 +1293,104 @@
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
     },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@poppinss/colors": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
@@ -2186,7 +2285,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.8.tgz",
       "integrity": "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
         "@astrojs/internal-helpers": "0.10.0",
@@ -4524,6 +4622,25 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -4897,7 +5014,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5113,8 +5229,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -5228,7 +5343,6 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -5535,7 +5649,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -5649,7 +5762,6 @@
       "integrity": "sha512-GApQvFX52SDM6L4u0+RRnUDB1wJOnEwoXjinkmOPtIyofWBxrlZckdegJSYc1leg++lLZ3+DQ4zMVmBqYVtzfA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -5669,7 +5781,6 @@
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.105.0.tgz",
       "integrity": "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g==",
       "license": "MIT OR Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.5.0",
         "@cloudflare/unenv-preset": "2.16.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && pagefind --site dist/client",
     "preview": "npm run build && wrangler dev",
     "test": "echo \"Error: no test specified\" && exit 1",
     "deploy": "npm run build && wrangler deploy",
@@ -31,6 +31,7 @@
     "tailwindcss": "^4.1.13"
   },
   "devDependencies": {
+    "pagefind": "^1.5.2",
     "wrangler": "^4.68.0"
   }
 }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -46,6 +46,20 @@ function isActive(href: string): boolean {
             )}
           </a>
         ))}
+
+        <!-- Search -->
+        <a
+          href="/search"
+          aria-label="Search"
+          class:list={[
+            'transition-colors',
+            isActive('/search') ? 'text-green' : 'text-white/80 hover:text-green',
+          ]}
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z" />
+          </svg>
+        </a>
       </nav>
 
       <!-- Mobile hamburger -->
@@ -86,6 +100,19 @@ function isActive(href: string): boolean {
           )}
         </a>
       ))}
+
+      <a
+        href="/search"
+        class:list={[
+          'flex items-center gap-2 py-2 text-sm font-medium transition-colors',
+          isActive('/search') ? 'text-green' : 'text-white/80 hover:text-green',
+        ]}
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z" />
+        </svg>
+        Search
+      </a>
     </nav>
   </div>
 </header>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -25,53 +25,61 @@ const ogImage = coverImage
 ---
 
 <BaseLayout title={title} description={description} ogImage={ogImage}>
-  <!-- Hero / cover image -->
-  {coverImage ? (
-    <div class="relative w-full max-h-[480px] overflow-hidden">
-      <Image
-        src={coverImage}
-        alt={title}
-        width={1600}
-        height={900}
-        class="w-full h-full object-cover"
-      />
-      <div class="absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-navy to-transparent" />
-    </div>
-  ) : (
-    <div class="w-full h-32 bg-gradient-to-r from-navy via-linkblue to-navy border-b border-green/20" />
-  )}
-
-  <!-- Post header -->
-  <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-4 border-b border-green/10">
-    {categories.length > 0 && (
-      <div class="flex flex-wrap gap-2 mb-4">
-        {categories.map(cat => (
-          <span class="text-xs font-semibold uppercase tracking-widest text-green">
-            {cat}
-          </span>
-        ))}
+  <!--
+    data-pagefind-body scopes Pagefind's index to the post itself — the title,
+    date, categories and rendered markdown — so the Header/Footer chrome that
+    repeats on every page never lands in a search result.
+  -->
+  <div data-pagefind-body>
+    <!-- Hero / cover image -->
+    {coverImage ? (
+      <div class="relative w-full max-h-[480px] overflow-hidden">
+        <Image
+          src={coverImage}
+          alt={title}
+          width={1600}
+          height={900}
+          class="w-full h-full object-cover"
+        />
+        <div class="absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-navy to-transparent" />
       </div>
+    ) : (
+      <div class="w-full h-32 bg-gradient-to-r from-navy via-linkblue to-navy border-b border-green/20" />
     )}
-    <h1 class="text-3xl sm:text-4xl font-bold text-white leading-tight mb-3">{title}</h1>
-    <p class="text-white/50 text-sm">{formattedDate}</p>
+
+    <!-- Post header -->
+    <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-4 border-b border-green/10">
+      {categories.length > 0 && (
+        <div class="flex flex-wrap gap-2 mb-4">
+          {categories.map(cat => (
+            <span class="text-xs font-semibold uppercase tracking-widest text-green">
+              {cat}
+            </span>
+          ))}
+        </div>
+      )}
+      <h1 class="text-3xl sm:text-4xl font-bold text-white leading-tight mb-3">{title}</h1>
+      <p class="text-white/50 text-sm">{formattedDate}</p>
+    </div>
+
+    <!-- Post content -->
+    <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
+      <article class="prose prose-invert prose-lg max-w-none
+        prose-headings:text-white
+        prose-a:text-green prose-a:no-underline prose-a:hover:underline
+        prose-strong:text-white
+        prose-code:text-green prose-code:bg-white/10 prose-code:px-1 prose-code:rounded
+        prose-pre:bg-white/5 prose-pre:border prose-pre:border-white/10
+        prose-blockquote:border-l-green prose-blockquote:text-white/70
+        prose-img:rounded-lg prose-img:mx-auto
+      ">
+        <slot />
+      </article>
+    </div>
   </div>
 
-  <!-- Post content -->
-  <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
-    <article class="prose prose-invert prose-lg max-w-none
-      prose-headings:text-white
-      prose-a:text-green prose-a:no-underline prose-a:hover:underline
-      prose-strong:text-white
-      prose-code:text-green prose-code:bg-white/10 prose-code:px-1 prose-code:rounded
-      prose-pre:bg-white/5 prose-pre:border prose-pre:border-white/10
-      prose-blockquote:border-l-green prose-blockquote:text-white/70
-      prose-img:rounded-lg prose-img:mx-auto
-    ">
-      <slot />
-    </article>
-    <!-- Plausible send blog post view event -->
-    <script>
-      window.plausible?.('Blog Post View', { props: { title:document.title } });
-    </script>
-  </div>
+  <!-- Plausible send blog post view event -->
+  <script>
+    window.plausible?.('Blog Post View', { props: { title:document.title } });
+  </script>
 </BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,7 +3,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="About Me" description="About Dom Kirby — cybersecurity professional, content creator, and technology enthusiast.">
-  <section class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+  <!-- data-pagefind-body: index this page's own content, not the site chrome -->
+  <section class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16" data-pagefind-body>
 
     <!-- Header: headshot + name -->
     <div class="flex flex-col sm:flex-row items-center sm:items-start gap-8 mb-10">

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -3,7 +3,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Contact" description="Get in touch with Dom Kirby.">
-  <section class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+  <!-- data-pagefind-body: index this page's own content, not the site chrome -->
+  <section class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16" data-pagefind-body>
     <h1 class="text-4xl font-bold text-white mb-4">Contact</h1>
     <p class="text-white/70 mb-10">
       Have a question, a speaking opportunity, or just want to say hello? Reach out using

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -16,8 +16,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <section class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
     <h1 class="text-4xl font-bold text-white mb-4">Search</h1>
     <p class="text-white/70 mb-10">
-      Search across every post and page on this site. Results are matched against
-      post content only &mdash; no navigation or footer noise.
+      Search across every post and page.
     </p>
 
     <div id="search"></div>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,0 +1,181 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="Search"
+  description="Search posts and pages on domkirby.com."
+>
+  <!--
+    Pagefind's UI bundle is generated into dist/pagefind/ by the `pagefind`
+    step of `npm run build`, so it does not exist during `astro dev` and can't
+    be resolved by Vite. It's loaded from its absolute public URL instead.
+  -->
+  <link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
+
+  <section class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+    <h1 class="text-4xl font-bold text-white mb-4">Search</h1>
+    <p class="text-white/70 mb-10">
+      Search across every post and page on this site. Results are matched against
+      post content only &mdash; no navigation or footer noise.
+    </p>
+
+    <div id="search"></div>
+
+    <noscript>
+      <p class="text-white/70">
+        Search needs JavaScript enabled. You can browse the
+        <a href="/blog" class="text-green hover:underline">full post archive</a> instead.
+      </p>
+    </noscript>
+  </section>
+</BaseLayout>
+
+<!--
+  Theme overrides for Pagefind's default UI, scoped to #search so they can't
+  leak into another Pagefind instance elsewhere on the site. Colors come from
+  the @theme tokens in src/styles/global.css.
+-->
+<style is:global>
+  #search {
+    --pagefind-ui-scale: 0.9;
+    --pagefind-ui-primary: var(--color-green);
+    --pagefind-ui-text: #ffffff;
+    --pagefind-ui-background: transparent;
+    --pagefind-ui-border: color-mix(in srgb, var(--color-green) 25%, transparent);
+    --pagefind-ui-tag: color-mix(in srgb, #ffffff 8%, transparent);
+    --pagefind-ui-border-width: 1px;
+    --pagefind-ui-border-radius: 0.75rem;
+    --pagefind-ui-image-border-radius: 0.5rem;
+    --pagefind-ui-font: inherit;
+  }
+
+  /* Search input — match the card/input treatment used elsewhere on the site. */
+  #search .pagefind-ui__search-input {
+    background-color: color-mix(in srgb, #ffffff 5%, transparent);
+    color: #ffffff;
+    font-weight: 500;
+  }
+
+  #search .pagefind-ui__search-input::placeholder {
+    color: color-mix(in srgb, #ffffff 40%, transparent);
+  }
+
+  #search .pagefind-ui__search-input:focus {
+    outline: none;
+    border-color: color-mix(in srgb, var(--color-green) 60%, transparent);
+  }
+
+  #search .pagefind-ui__search-clear {
+    background-color: transparent;
+    color: color-mix(in srgb, #ffffff 60%, transparent);
+  }
+
+  #search .pagefind-ui__search-clear:hover {
+    color: var(--color-green);
+  }
+
+  /* Result count / "load more" chrome. */
+  #search .pagefind-ui__message {
+    color: color-mix(in srgb, #ffffff 60%, transparent);
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+
+  #search .pagefind-ui__button {
+    background-color: color-mix(in srgb, #ffffff 5%, transparent);
+    border: 1px solid color-mix(in srgb, #ffffff 20%, transparent);
+    border-radius: 0.5rem;
+    color: #ffffff;
+    font-weight: 500;
+  }
+
+  #search .pagefind-ui__button:hover {
+    border-color: color-mix(in srgb, var(--color-green) 40%, transparent);
+    color: var(--color-green);
+  }
+
+  /* Result cards. */
+  #search .pagefind-ui__result {
+    border-top: 1px solid color-mix(in srgb, #ffffff 10%, transparent);
+  }
+
+  #search .pagefind-ui__result-title .pagefind-ui__result-link {
+    color: #ffffff;
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  #search .pagefind-ui__result-title .pagefind-ui__result-link:hover {
+    color: var(--color-green);
+    text-decoration: none;
+  }
+
+  #search .pagefind-ui__result-excerpt {
+    color: color-mix(in srgb, #ffffff 70%, transparent);
+  }
+
+  /* Pagefind marks matched terms with <mark>. */
+  #search .pagefind-ui__result-excerpt mark {
+    background-color: transparent;
+    color: var(--color-green);
+    font-weight: 700;
+  }
+
+  #search .pagefind-ui__result-nested .pagefind-ui__result-link {
+    color: color-mix(in srgb, #ffffff 80%, transparent);
+    text-decoration: none;
+  }
+
+  #search .pagefind-ui__result-nested .pagefind-ui__result-link:hover {
+    color: var(--color-green);
+  }
+</style>
+
+<!--
+  is:inline keeps Astro/Vite from trying to resolve the /pagefind/ import at
+  build time — the bundle only exists in dist/ after the pagefind CLI runs.
+-->
+<script is:inline>
+  (async () => {
+    const container = document.querySelector('#search');
+    if (!container) return;
+
+    try {
+      // pagefind-ui.js is an IIFE bundle — importing it runs the bundle, which
+      // assigns window.PagefindUI. It has no ES module exports to destructure.
+      await import('/pagefind/pagefind-ui.js');
+      if (typeof window.PagefindUI !== 'function') throw new Error('PagefindUI missing');
+    } catch {
+      container.innerHTML =
+        '<p class="text-white/70">Search is unavailable right now. ' +
+        'The Pagefind index is only built by <code>npm run build</code>, ' +
+        'so it is not present in <code>npm run dev</code>. ' +
+        '<a class="text-green hover:underline" href="/blog">Browse the archive</a> instead.</p>';
+      return;
+    }
+
+    const ui = new window.PagefindUI({
+      element: '#search',
+      showSubResults: true,
+    });
+
+    // Allow linking straight to a search from anywhere on the site: /search?q=term
+    const query = new URLSearchParams(window.location.search).get('q');
+    if (query) {
+      if (typeof ui.triggerSearch === 'function') {
+        ui.triggerSearch(query);
+      } else {
+        const input = container.querySelector('.pagefind-ui__search-input');
+        if (input) {
+          input.value = query;
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+      }
+    }
+
+    container.querySelector('.pagefind-ui__search-input')?.focus();
+  })();
+</script>

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -22,7 +22,8 @@ const tools = [
 ---
 
 <BaseLayout title="Tools and Stuff" description="Tools and software Dom Kirby uses and recommends.">
-  <section class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+  <!-- data-pagefind-body: index this page's own content, not the site chrome -->
+  <section class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16" data-pagefind-body>
     <h1 class="text-4xl font-bold text-white mb-4">Tools and Stuff</h1>
     <p class="text-white/70 mb-12">
       A curated list of tools, software, and resources I use and recommend. This page is updated


### PR DESCRIPTION
Adds site-wide search powered by [Pagefind](https://pagefind.app), which builds a static search index from the site's own built HTML. No backend, no third-party service — the index ships as static files alongside the rest of the site.

## Changes

- **`pagefind` as a dev dependency**, run from the `build` script. `dev` and `preview` are untouched.
- **Scoped indexing via `data-pagefind-body`:**
  - `PostLayout.astro` — post title, date, categories and rendered markdown.
  - `about.astro`, `tools.astro`, `contact.astro` — each page's content `<section>`. These use `BaseLayout` directly rather than `PostLayout`, so they'd otherwise be unsearchable.
  - Home, blog archive, `404` and `/search` are deliberately left unmarked. Pagefind skips pages without the attribute, and these only re-aggregate content that's already indexed at its source.
  - `Header.astro` / `Footer.astro` chrome stays out of the index entirely.
- **New `/search` page** — mounts Pagefind's default UI with `showSubResults: true`, autofocuses the input, and accepts a `?q=` parameter so a search can be linked to from anywhere (`/search?q=passkeys`). Degrades to an explanatory message under `npm run dev`, where no index exists.
- **Themed UI** — Pagefind's default styles remapped to the site palette using its CSS custom properties plus a few targeted rules, all scoped under `#search` so the overrides can't leak into a future Pagefind instance.
- **Nav entry point** — magnifying-glass icon in the desktop bar (matching the existing `text-white/80 hover:text-green` + active-state convention), labelled "Search" link in the mobile panel.
- **README** — new "Search" section covering the build-time indexing, why the index isn't visible in `npm run dev`, how to test locally, and what gets indexed.

## Note on the Pagefind target directory

The build script runs `pagefind --site dist/client`, **not** `--site dist`.

The Cloudflare adapter emits static HTML into `dist/client/` and the worker into `dist/server/`, and its generated deploy config (`dist/server/wrangler.json`) sets `assets.directory: "../client"` — so `dist/client` is the served site root. Indexing `dist` instead produced result URLs prefixed with `/client/` (e.g. `/client/blog/white-house-cyber-strategy/`) and wrote the index to `dist/pagefind/`, outside the served asset root, so `/pagefind/pagefind-ui.js` would have 404'd in production.

No deploy configuration was modified — `wrangler.jsonc` is untouched.

Also worth noting: `pagefind-ui.js` is an IIFE that assigns `window.PagefindUI` and has no ES module exports, so the page imports the URL for its side effect and then reads `window.PagefindUI`.

## Verification

Clean `npm run build`: 104 pages indexed, no errors, `dist/client/pagefind/` generated. Under `npm run preview`, driven in Chromium:

- `/pagefind/pagefind-ui.js` and `/pagefind/pagefind-ui.css` both return 200.
- `passkeys` → 12 results, top hit "Entra Synced Passkeys and Passkey Profiles" at `/blog/entra-synced-passkeys-passkey-profiles/`, with sub-results and cover-image thumbnails. Result URLs are clean, no `/client/` prefix.
- `/search?q=My%202026%20Cyber%20and%20Other%20Predictions` → input pre-filled, search triggered, 1 correct result. Query strings survive Astro's `/search` → `/search/` 307 redirect.
- Searching for nav labels returned 1 incidental post rather than all 104 pages, confirming site chrome isn't in the index.
- `/about/`, `/tools/` and `/contact/` each rank first for their own content; the home page and blog archive are absent from results as intended.
- Computed styles confirm the theme applied — match highlight is `rgb(126, 217, 87)` (`#7ed957`).

## Unrelated observation

Several older WordPress-era posts still contain raw Divi shortcodes (`[et_pb_section ...]`) in their body text, which lands in the index and can surface in search excerpts. Pre-existing content issue, not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrQ7mTEubMmL9SJe4PYJ2W)_